### PR TITLE
chore(ci): harden upstream sync and CI gates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @lin-mouren
+
+# Require explicit review for CI and sync automation changes.
+.github/workflows/* @lin-mouren

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+Describe what changed and why.
+
+## Change Type
+
+- [ ] Feature
+- [ ] Bugfix
+- [ ] Refactor
+- [ ] Chore
+- [ ] Upstream sync
+
+## Validation
+
+- [ ] CI passed (`CI / lint`, `CI / build`)
+- [ ] Manual verification completed (if applicable)
+
+## Upstream Sync Checklist (if `mirror/upstream-main -> main`)
+
+- [ ] Source PR branch is `mirror/upstream-main` or `sync/upstream-*`
+- [ ] Merge method is **Create a merge commit**
+- [ ] Conflicts, if any, were resolved outside `mirror/upstream-main`
+
+## Risks / Rollback
+
+List known risks and rollback steps.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "yarn"
@@ -23,8 +23,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "yarn"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "yarn"
@@ -37,7 +37,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: windows-builds
           path: |
@@ -50,10 +50,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "yarn"
@@ -70,7 +70,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: macos-builds
           path: |
@@ -83,10 +83,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "24"
           cache: "yarn"
@@ -103,7 +103,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: linux-builds
           path: |
@@ -121,25 +121,25 @@ jobs:
 
     steps:
       - name: Download Windows artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: windows-builds
           path: dist
 
       - name: Download macOS artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: macos-builds
           path: dist
 
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: linux-builds
           path: dist
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@6da8fa9354ddfdc4aeace5fc48d7f679b5214090 # v2.4.1
         with:
           name: ToonFlow ${{ github.ref_name }}
           draft: false

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -15,11 +15,13 @@ jobs:
     permissions:
       contents: write
     outputs:
+      upstream_branch: ${{ steps.sync.outputs.upstream_branch }}
       upstream_sha: ${{ steps.sync.outputs.upstream_sha }}
       mirror_sha: ${{ steps.sync.outputs.mirror_sha }}
       ff_ok: ${{ steps.sync.outputs.ff_ok }}
+      ff_failure_reason: ${{ steps.sync.outputs.ff_failure_reason }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -37,8 +39,15 @@ jobs:
             git remote add upstream https://github.com/HBAI-Ltd/Toonflow-app.git
           fi
 
-          git fetch --no-tags upstream master
-          upstream_sha="$(git rev-parse upstream/master)"
+          upstream_branch="$(git ls-remote --symref upstream HEAD | awk '/^ref:/ {sub("refs/heads/","",$2); print $2; exit}')"
+          if [[ -z "$upstream_branch" ]]; then
+            upstream_branch="master"
+          fi
+          echo "upstream_branch=$upstream_branch" >> "$GITHUB_OUTPUT"
+
+          git fetch --no-tags upstream "$upstream_branch"
+          upstream_ref="upstream/$upstream_branch"
+          upstream_sha="$(git rev-parse "$upstream_ref")"
           echo "upstream_sha=$upstream_sha" >> "$GITHUB_OUTPUT"
 
           if git ls-remote --exit-code --heads origin mirror/upstream-main >/dev/null 2>&1; then
@@ -46,17 +55,28 @@ jobs:
             git switch --detach origin/mirror/upstream-main
             git switch -c mirror/upstream-main
           else
-            git switch --detach upstream/master
+            git switch --detach "$upstream_ref"
             git switch -c mirror/upstream-main
           fi
 
           # Hard requirement: mirror only accepts fast-forward from upstream.
-          git merge --ff-only upstream/master
+          if ! git merge-base --is-ancestor HEAD "$upstream_ref"; then
+            echo "ff_ok=false" >> "$GITHUB_OUTPUT"
+            echo "ff_failure_reason=mirror branch is not an ancestor of $upstream_ref" >> "$GITHUB_OUTPUT"
+            echo "mirror_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git merge --ff-only "$upstream_ref"
           mirror_sha="$(git rev-parse HEAD)"
           echo "mirror_sha=$mirror_sha" >> "$GITHUB_OUTPUT"
-          echo "ff_ok=true" >> "$GITHUB_OUTPUT"
 
-          git push origin HEAD:refs/heads/mirror/upstream-main
+          if git push origin HEAD:refs/heads/mirror/upstream-main; then
+            echo "ff_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ff_ok=false" >> "$GITHUB_OUTPUT"
+            echo "ff_failure_reason=push to origin/mirror/upstream-main failed" >> "$GITHUB_OUTPUT"
+          fi
 
   ensure_pr:
     runs-on: ubuntu-latest
@@ -66,10 +86,12 @@ jobs:
     permissions:
       pull-requests: write
       contents: read
+      issues: write
     env:
       GH_TOKEN: ${{ github.token }}
       BASE: main
       HEAD: mirror/upstream-main
+      UPSTREAM_BRANCH: ${{ needs.sync_mirror.outputs.upstream_branch }}
       UPSTREAM_SHA: ${{ needs.sync_mirror.outputs.upstream_sha }}
     steps:
       - name: Create or reuse PR (mirror -> main)
@@ -85,14 +107,59 @@ jobs:
             exit 0
           fi
 
+          gh label create "source:upstream" --color "1D76DB" --description "Automated upstream mirror sync PRs" || true
+
           existing="$(gh pr list --state open --base "$BASE" --head "$HEAD" --json number --jq '.[0].number')"
           title="chore(upstream): sync ${UPSTREAM_SHA:0:7}"
           body=$'Sync upstream -> mirror, then PR into main.\n\n'
-          body+=$'- Upstream: `HBAI-Ltd/Toonflow-app@'"$UPSTREAM_SHA"$'`\n'
+          body+=$'- Upstream: `HBAI-Ltd/Toonflow-app ('"$UPSTREAM_BRANCH"$') @ '"$UPSTREAM_SHA"$'`\n'
           body+=$'- Mirror: `'"$HEAD"$'`\n'
 
           if [[ -z "$existing" ]]; then
-            gh pr create --base "$BASE" --head "$HEAD" --title "$title" --body "$body"
+            gh pr create --base "$BASE" --head "$HEAD" --title "$title" --body "$body" --label "source:upstream"
           else
-            gh pr edit "$existing" --title "$title" --body "$body"
+            gh pr edit "$existing" --title "$title" --body "$body" --add-label "source:upstream"
+          fi
+
+  open_break_glass_issue:
+    runs-on: ubuntu-latest
+    needs:
+      - sync_mirror
+    if: needs.sync_mirror.outputs.ff_ok != 'true'
+    permissions:
+      issues: write
+      contents: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+      UPSTREAM_BRANCH: ${{ needs.sync_mirror.outputs.upstream_branch }}
+      UPSTREAM_SHA: ${{ needs.sync_mirror.outputs.upstream_sha }}
+      MIRROR_SHA: ${{ needs.sync_mirror.outputs.mirror_sha }}
+      REASON: ${{ needs.sync_mirror.outputs.ff_failure_reason }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      - name: Open or update break-glass issue
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          title="break-glass: mirror fast-forward failed"
+          body=$'The automated upstream mirror sync could not complete as fast-forward.\n\n'
+          body+=$'- Reason: `'"${REASON:-unknown}"$'`\n'
+          body+=$'- Upstream branch: `'"${UPSTREAM_BRANCH:-unknown}"$'`\n'
+          body+=$'- Upstream sha: `'"${UPSTREAM_SHA:-unknown}"$'`\n'
+          body+=$'- Mirror sha: `'"${MIRROR_SHA:-unknown}"$'`\n'
+          body+=$'- Run: '"$RUN_URL"$'\n\n'
+          body+=$'Break-glass runbook:\n'
+          body+=$'1. Temporarily allow force-push on `mirror/upstream-main`.\n'
+          body+=$'2. `git fetch --prune upstream && git checkout mirror/upstream-main && git reset --hard upstream/'"${UPSTREAM_BRANCH:-master}"$'`\n'
+          body+=$'3. `git push --force-with-lease origin mirror/upstream-main`\n'
+          body+=$'4. Disable force-push again.\n'
+
+          gh label create "source:upstream" --color "1D76DB" --description "Automated upstream mirror sync PRs" || true
+
+          existing="$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number')"
+          if [[ -z "$existing" ]]; then
+            gh issue create --title "$title" --body "$body" --label "source:upstream"
+          else
+            gh issue comment "$existing" --body "$body"
           fi

--- a/src/routes/other/testVideo.ts
+++ b/src/routes/other/testVideo.ts
@@ -36,6 +36,9 @@ export default router.post(
           manufacturer,
         },
       );
+      if (typeof videoPath !== "string" || videoPath.length === 0) {
+        throw new Error("Video generation returned an invalid file path");
+      }
       const url = await u.oss.getFileUrl(videoPath);
       res.status(200).send(success(url));
     } catch (err: any) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,6 @@
     "incremental": true,
     "typeRoots": ["./node_modules/@types", "./types"],
     "resolveJsonModule": true
-  }
+  },
+  "exclude": ["backup", "build", "dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
- pin GitHub Actions by commit SHA
- make upstream sync detect upstream default branch dynamically
- auto-open/update break-glass issue when mirror fast-forward fails
- add CODEOWNERS and PR template for governance
- unblock lint gate by excluding backup artifacts and fixing testVideo type safety

## Validation
- yarn lint
- yarn build
