### PR TITLE
docs: add org migration and strict mirror enforcement toolkit

### DIFF
--- a/docs/org-migration-strict-mirror.md
+++ b/docs/org-migration-strict-mirror.md
@@ -1,0 +1,37 @@
+# Org Migration + Strict Mirror Enforcement
+
+This guide is for enforcing **actor-level push restrictions** on `mirror/upstream-main`.
+GitHub personal repositories cannot strictly enforce "only GitHub Actions can push this branch."
+Use this flow after moving the repository to an Organization.
+
+## Target state
+
+- Repository owner is an Organization.
+- `main` remains the product iteration branch with PR + CI gates.
+- `mirror/upstream-main` allows pushes from `github-actions` app only.
+- `master` is locked (legacy branch, read-only).
+
+## Migration checklist
+
+1. Transfer the repository to an Organization you control:
+   - GitHub UI: `Settings` -> `General` -> `Transfer`.
+   - Or CLI: `gh repo transfer <org-name>`.
+2. Confirm the default branch is `main`.
+3. Confirm workflows exist on `main`:
+   - `.github/workflows/ci.yml`
+   - `.github/workflows/upstream-sync.yml`
+4. Run the automation script:
+
+```bash
+./scripts/github/apply-org-branch-protection.sh <org>/<repo>
+```
+
+5. Validate:
+   - Direct push to `main` is blocked.
+   - Direct push to `mirror/upstream-main` is blocked for humans.
+   - `Upstream Sync` workflow can still update `mirror/upstream-main`.
+
+## Notes
+
+- If your org has custom rulesets, keep this script as baseline and layer org rulesets on top.
+- If `mirror` fast-forward fails due upstream history rewrite, use the break-glass process from `docs/upstream-sync-runbook.md`.

--- a/scripts/github/apply-org-branch-protection.sh
+++ b/scripts/github/apply-org-branch-protection.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -gt 1 ]]; then
+  echo "Usage: $0 [owner/repo]"
+  exit 1
+fi
+
+if [[ $# -eq 1 ]]; then
+  REPO="$1"
+else
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    origin_url="$(git remote get-url origin 2>/dev/null || true)"
+    if [[ "$origin_url" == https://github.com/*/* || "$origin_url" == git@github.com:*/* ]]; then
+      REPO="$(printf '%s' "$origin_url" | sed -E 's#^https://github.com/##; s#^git@github.com:##; s#\\.git$##')"
+      REPO="${REPO%.git}"
+    fi
+  fi
+  if [[ -z "${REPO:-}" ]]; then
+    REPO="$(gh repo view --json nameWithOwner --jq '.nameWithOwner')"
+  fi
+fi
+
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO##*/}"
+
+owner_type="$(gh api "users/${OWNER}" --jq '.type')"
+if [[ "${owner_type}" != "Organization" ]]; then
+  echo "Error: ${REPO} is not owned by an Organization (owner type: ${owner_type})."
+  echo "Strict actor-level push restrictions for mirror require an Organization repo."
+  exit 2
+fi
+
+echo "Applying repository settings to ${REPO} ..."
+gh api -X PATCH "repos/${REPO}" \
+  -f default_branch=main \
+  -F allow_merge_commit=true \
+  -F allow_squash_merge=false \
+  -F allow_rebase_merge=false \
+  -F delete_branch_on_merge=true >/dev/null
+
+echo "Ensuring workflow token permissions ..."
+gh api -X PUT "repos/${REPO}/actions/permissions/workflow" \
+  -f default_workflow_permissions=write \
+  -F can_approve_pull_request_reviews=true >/dev/null
+
+tmp_main="$(mktemp)"
+tmp_mirror="$(mktemp)"
+tmp_master="$(mktemp)"
+trap 'rm -f "$tmp_main" "$tmp_mirror" "$tmp_master"' EXIT
+
+cat >"$tmp_main" <<'JSON'
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": ["CI / lint", "CI / build"]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "required_approving_review_count": 1,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+JSON
+
+cat >"$tmp_mirror" <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": {
+    "users": [],
+    "teams": [],
+    "apps": ["github-actions"]
+  },
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": false,
+  "allow_fork_syncing": false
+}
+JSON
+
+cat >"$tmp_master" <<'JSON'
+{
+  "required_status_checks": null,
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false,
+  "required_conversation_resolution": false,
+  "lock_branch": true,
+  "allow_fork_syncing": false
+}
+JSON
+
+echo "Protecting main ..."
+gh api -X PUT "repos/${REPO}/branches/main/protection" \
+  -H "Accept: application/vnd.github+json" \
+  --input "$tmp_main" >/dev/null
+
+echo "Protecting mirror/upstream-main (github-actions push only) ..."
+gh api -X PUT "repos/${REPO}/branches/mirror%2Fupstream-main/protection" \
+  -H "Accept: application/vnd.github+json" \
+  --input "$tmp_mirror" >/dev/null
+
+if gh api "repos/${REPO}/branches/master" >/dev/null 2>&1; then
+  echo "Locking legacy master ..."
+  gh api -X PUT "repos/${REPO}/branches/master/protection" \
+    -H "Accept: application/vnd.github+json" \
+    --input "$tmp_master" >/dev/null
+fi
+
+echo "Done."
+echo
+echo "Current branch list for ${REPO}:"
+gh api "repos/${REPO}/branches?per_page=100" --jq '.[].name'


### PR DESCRIPTION
## Summary
- add org migration checklist for strict mirror push enforcement
- add script to apply org-grade branch protection for main/mirror/master
- script validates owner type and exits on personal repos

## Validation
- executed script in current personal repo and verified expected guard failure message
