### PR TITLE
docs(governance): capture production environment readiness status

### DIFF
--- a/docs/governance-snapshot-2026-03-05.md
+++ b/docs/governance-snapshot-2026-03-05.md
@@ -1,8 +1,8 @@
 # Governance Snapshot: lin-mouren/Toonflow-app
 
 Generated at:
-- Local time: 2026-03-05 20:43:22 CST
-- UTC time: 2026-03-05T12:43:22Z
+- Local time: 2026-03-05 20:53:30 CST
+- UTC time: 2026-03-05T12:53:30Z
 
 ## Repository settings
 
@@ -33,8 +33,18 @@ Generated at:
 - upstream repository: `HBAI-Ltd/Toonflow-app`
 - upstream default branch: `master`
 - compare status (`mirror/upstream-main...main`): `ahead`
-- compare ahead_by: `9`
+- compare ahead_by: `12`
 - compare behind_by: `0`
 - mirror sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
 - upstream sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
 - mirror equals upstream: `true`
+
+## Security and deployment hardening status
+
+- secret_scanning: `enabled`
+- secret_scanning_push_protection: `enabled`
+- dependabot_security_updates: `disabled`
+- production_environment_exists: `true`
+- production_can_admins_bypass: `true`
+- production_branch_policy: `{"custom_branch_policies":false,"protected_branches":true}`
+- production_has_required_reviewers: `false`

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -9,6 +9,13 @@ This document operationalizes pending production hardening tasks while the repos
 - Branch model: `main` + `mirror/upstream-main`
 - Current policy: no strict actor-level mirror push restriction
 
+## Current status (as of 2026-03-05)
+
+- `production` environment has been created with `protected_branches=true`.
+- `production` required reviewers are not configured yet.
+- `secret_scanning` and `secret_scanning_push_protection` are enabled.
+- `dependabot_security_updates` is still disabled.
+
 ## P0: Deployment environment protection
 
 Goal: block accidental production release without explicit approval.

--- a/scripts/github/snapshot-governance-state.sh
+++ b/scripts/github/snapshot-governance-state.sh
@@ -58,6 +58,22 @@ upstream_default_branch="$(gh repo view "$UPSTREAM_REPO" --json defaultBranchRef
 mirror_sha="$(gh api "repos/${REPO}/git/ref/heads/mirror/upstream-main" --jq '.object.sha')"
 upstream_sha="$(gh api "repos/${UPSTREAM_REPO}/git/ref/heads/${upstream_default_branch}" --jq '.object.sha')"
 
+secret_scanning_status="$(gh api "repos/${REPO}" --jq '.security_and_analysis.secret_scanning.status // "unknown"')"
+secret_scanning_push_protection_status="$(gh api "repos/${REPO}" --jq '.security_and_analysis.secret_scanning_push_protection.status // "unknown"')"
+dependabot_security_updates_status="$(gh api "repos/${REPO}" --jq '.security_and_analysis.dependabot_security_updates.status // "unknown"')"
+
+if gh api "repos/${REPO}/environments/production" >/dev/null 2>&1; then
+  production_environment_exists="true"
+  production_can_admins_bypass="$(gh api "repos/${REPO}/environments/production" --jq '.can_admins_bypass')"
+  production_branch_policy="$(gh api "repos/${REPO}/environments/production" --jq '.deployment_branch_policy | tostring')"
+  production_has_required_reviewers="$(gh api "repos/${REPO}/environments/production" --jq 'any(.protection_rules[]?; .type == "required_reviewers")')"
+else
+  production_environment_exists="false"
+  production_can_admins_bypass="unknown"
+  production_branch_policy="unknown"
+  production_has_required_reviewers="unknown"
+fi
+
 mkdir -p "$(dirname "$OUT_FILE")"
 cat >"$OUT_FILE" <<EOF
 # Governance Snapshot: ${REPO}
@@ -100,6 +116,16 @@ Generated at:
 - mirror sha: \`${mirror_sha}\`
 - upstream sha: \`${upstream_sha}\`
 - mirror equals upstream: \`$([[ "$mirror_sha" == "$upstream_sha" ]] && echo true || echo false)\`
+
+## Security and deployment hardening status
+
+- secret_scanning: \`${secret_scanning_status}\`
+- secret_scanning_push_protection: \`${secret_scanning_push_protection_status}\`
+- dependabot_security_updates: \`${dependabot_security_updates_status}\`
+- production_environment_exists: \`${production_environment_exists}\`
+- production_can_admins_bypass: \`${production_can_admins_bypass}\`
+- production_branch_policy: \`${production_branch_policy}\`
+- production_has_required_reviewers: \`${production_has_required_reviewers}\`
 EOF
 
 echo "Wrote ${OUT_FILE}"


### PR DESCRIPTION
## Summary
- extend governance snapshot script to record security toggles and production environment state
- regenerate governance snapshot with live status after creating production environment baseline
- update production readiness checklist with current-state section

## Why
This closes the remaining observability gap in the implementation by making production hardening drift visible in versioned docs.

## Validation
- production environment exists with branch policy ()
- snapshot now records: secret scanning, push protection, dependabot security updates, production reviewers presence