### PR TITLE
docs(governance): sync dependabot-enabled status

### DIFF
--- a/docs/governance-snapshot-2026-03-05.md
+++ b/docs/governance-snapshot-2026-03-05.md
@@ -1,8 +1,8 @@
 # Governance Snapshot: lin-mouren/Toonflow-app
 
 Generated at:
-- Local time: 2026-03-05 20:53:30 CST
-- UTC time: 2026-03-05T12:53:30Z
+- Local time: 2026-03-05 20:59:16 CST
+- UTC time: 2026-03-05T12:59:16Z
 
 ## Repository settings
 
@@ -33,7 +33,7 @@ Generated at:
 - upstream repository: `HBAI-Ltd/Toonflow-app`
 - upstream default branch: `master`
 - compare status (`mirror/upstream-main...main`): `ahead`
-- compare ahead_by: `12`
+- compare ahead_by: `14`
 - compare behind_by: `0`
 - mirror sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
 - upstream sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
@@ -43,7 +43,7 @@ Generated at:
 
 - secret_scanning: `enabled`
 - secret_scanning_push_protection: `enabled`
-- dependabot_security_updates: `disabled`
+- dependabot_security_updates: `enabled`
 - production_environment_exists: `true`
 - production_can_admins_bypass: `true`
 - production_branch_policy: `{"custom_branch_policies":false,"protected_branches":true}`

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -14,7 +14,7 @@ This document operationalizes pending production hardening tasks while the repos
 - `production` environment has been created with `protected_branches=true`.
 - `production` required reviewers are not configured yet.
 - `secret_scanning` and `secret_scanning_push_protection` are enabled.
-- `dependabot_security_updates` is still disabled.
+- `dependabot_security_updates` is enabled.
 
 ## P0: Deployment environment protection
 


### PR DESCRIPTION
## Summary
- refresh governance snapshot after enabling Dependabot security updates
- update readiness checklist current-state section to match live security settings

## Why
Keeps repo documentation consistent with production hardening state actually applied on GitHub settings.