### PR TITLE
docs(governance): sync production reviewer enforcement status

### DIFF
--- a/docs/governance-snapshot-2026-03-05.md
+++ b/docs/governance-snapshot-2026-03-05.md
@@ -1,8 +1,8 @@
 # Governance Snapshot: lin-mouren/Toonflow-app
 
 Generated at:
-- Local time: 2026-03-05 20:59:16 CST
-- UTC time: 2026-03-05T12:59:16Z
+- Local time: 2026-03-05 21:26:11 CST
+- UTC time: 2026-03-05T13:26:11Z
 
 ## Repository settings
 
@@ -33,7 +33,7 @@ Generated at:
 - upstream repository: `HBAI-Ltd/Toonflow-app`
 - upstream default branch: `master`
 - compare status (`mirror/upstream-main...main`): `ahead`
-- compare ahead_by: `14`
+- compare ahead_by: `16`
 - compare behind_by: `0`
 - mirror sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
 - upstream sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
@@ -45,6 +45,6 @@ Generated at:
 - secret_scanning_push_protection: `enabled`
 - dependabot_security_updates: `enabled`
 - production_environment_exists: `true`
-- production_can_admins_bypass: `true`
+- production_can_admins_bypass: `false`
 - production_branch_policy: `{"custom_branch_policies":false,"protected_branches":true}`
-- production_has_required_reviewers: `false`
+- production_has_required_reviewers: `true`

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -12,7 +12,8 @@ This document operationalizes pending production hardening tasks while the repos
 ## Current status (as of 2026-03-05)
 
 - `production` environment has been created with `protected_branches=true`.
-- `production` required reviewers are not configured yet.
+- `production` required reviewer is configured (`lin-mouren`).
+- `production` admin bypass is disabled (`can_admins_bypass=false`).
 - `secret_scanning` and `secret_scanning_push_protection` are enabled.
 - `dependabot_security_updates` is enabled.
 


### PR DESCRIPTION
## Summary
- production environment now requires reviewer lin-mouren
- production admin bypass has been disabled
- refresh governance snapshot and readiness checklist to match live settings

## Why
Completes the next production-hardening step by turning on an actual approval gate and documenting the effective state.