### PR TITLE
chore(prod): close remaining P0/P1 gaps

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -136,6 +136,7 @@ jobs:
       MIRROR_SHA: ${{ needs.sync_mirror.outputs.mirror_sha }}
       REASON: ${{ needs.sync_mirror.outputs.ff_failure_reason }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      ALERT_WEBHOOK_URL: ${{ secrets.UPSTREAM_SYNC_ALERT_WEBHOOK_URL }}
     steps:
       - name: Open or update break-glass issue
         shell: bash
@@ -143,7 +144,9 @@ jobs:
           set -euo pipefail
 
           title="break-glass: mirror fast-forward failed"
+          owner_mention="@${GITHUB_REPOSITORY_OWNER}"
           body=$'The automated upstream mirror sync could not complete as fast-forward.\n\n'
+          body+=$'- Owner: '"$owner_mention"$'\n'
           body+=$'- Reason: `'"${REASON:-unknown}"$'`\n'
           body+=$'- Upstream branch: `'"${UPSTREAM_BRANCH:-unknown}"$'`\n'
           body+=$'- Upstream sha: `'"${UPSTREAM_SHA:-unknown}"$'`\n'
@@ -159,7 +162,41 @@ jobs:
 
           existing="$(gh issue list --state open --search "\"$title\" in:title" --json number --jq '.[0].number')"
           if [[ -z "$existing" ]]; then
-            gh issue create --title "$title" --body "$body" --label "source:upstream"
+            issue_url="$(gh issue create --title "$title" --body "$body" --label "source:upstream")"
           else
             gh issue comment "$existing" --body "$body"
+            issue_url="$(gh issue view "$existing" --json url --jq '.url')"
           fi
+
+          webhook_status="skipped"
+          if [[ -n "${ALERT_WEBHOOK_URL:-}" ]]; then
+            payload="$(jq -n \
+              --arg repo "$GITHUB_REPOSITORY" \
+              --arg reason "${REASON:-unknown}" \
+              --arg upstream_branch "${UPSTREAM_BRANCH:-unknown}" \
+              --arg upstream_sha "${UPSTREAM_SHA:-unknown}" \
+              --arg mirror_sha "${MIRROR_SHA:-unknown}" \
+              --arg run_url "$RUN_URL" \
+              --arg issue_url "${issue_url:-}" \
+              --arg owner "$owner_mention" \
+              '{text: ("[upstream-sync] break-glass required for " + $repo), repo: $repo, owner: $owner, reason: $reason, upstream_branch: $upstream_branch, upstream_sha: $upstream_sha, mirror_sha: $mirror_sha, run_url: $run_url, issue_url: $issue_url}')"
+            if curl -fsSL -X POST -H "Content-Type: application/json" --data "$payload" "$ALERT_WEBHOOK_URL" >/dev/null; then
+              webhook_status="sent"
+            else
+              webhook_status="failed"
+            fi
+          fi
+
+          {
+            echo "### Break-glass required"
+            echo "- Owner: ${owner_mention}"
+            echo "- Reason: \`${REASON:-unknown}\`"
+            echo "- Upstream: \`${UPSTREAM_BRANCH:-unknown}@${UPSTREAM_SHA:-unknown}\`"
+            echo "- Mirror sha: \`${MIRROR_SHA:-unknown}\`"
+            echo "- Issue: ${issue_url:-n/a}"
+            echo "- Webhook status: ${webhook_status}"
+            echo "- Run: ${RUN_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Keep the workflow red on ff-only failures even after notifications.
+          exit 1

--- a/docs/governance-snapshot-2026-03-05.md
+++ b/docs/governance-snapshot-2026-03-05.md
@@ -1,8 +1,8 @@
 # Governance Snapshot: lin-mouren/Toonflow-app
 
 Generated at:
-- Local time: 2026-03-05 21:26:11 CST
-- UTC time: 2026-03-05T13:26:11Z
+- Local time: 2026-03-05 23:59:23 CST
+- UTC time: 2026-03-05T15:59:23Z
 
 ## Repository settings
 
@@ -11,10 +11,13 @@ Generated at:
 - rebase_merge_allowed: `false`
 - squash_merge_allowed: `false`
 - delete_branch_on_merge: `true`
+- has_issues: `true`
+- default_workflow_permissions: `read`
 
 ## Branch protection: main
 
-- required_approving_review_count: `0`
+- required_approving_review_count: `1`
+- require_code_owner_reviews: `true`
 - required_status_checks: `lint, build`
 - enforce_admins: `true`
 - allow_force_pushes: `false`
@@ -33,7 +36,7 @@ Generated at:
 - upstream repository: `HBAI-Ltd/Toonflow-app`
 - upstream default branch: `master`
 - compare status (`mirror/upstream-main...main`): `ahead`
-- compare ahead_by: `16`
+- compare ahead_by: `18`
 - compare behind_by: `0`
 - mirror sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
 - upstream sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -11,11 +11,16 @@ This document operationalizes pending production hardening tasks while the repos
 
 ## Current status (as of 2026-03-05)
 
+- `issues` is enabled (`has_issues=true`) for break-glass incident tracking.
 - `production` environment has been created with `protected_branches=true`.
 - `production` required reviewer is configured (`lin-mouren`).
 - `production` admin bypass is disabled (`can_admins_bypass=false`).
 - `secret_scanning` and `secret_scanning_push_protection` are enabled.
 - `dependabot_security_updates` is enabled.
+- default workflow token permission is `read`; write permissions are job-scoped.
+- `main` protection now requires `1` approval with CODEOWNERS review.
+- release rollback runbook exists at `docs/release-rollback-runbook.md`.
+- upstream ff failure fan-out is configured via issue + owner mention + optional webhook secret `UPSTREAM_SYNC_ALERT_WEBHOOK_URL`.
 
 ## P0: Deployment environment protection
 
@@ -70,7 +75,7 @@ Validation:
 Goal: start fast with 0-approval gate, then raise review strength at production milestone.
 
 Current:
-- `main` required approvals: `0`
+- `main` required approvals: `1`
 - required checks: `lint`, `build`
 
 Upgrade path:

--- a/docs/release-rollback-runbook.md
+++ b/docs/release-rollback-runbook.md
@@ -1,0 +1,61 @@
+# Release Rollback Runbook
+
+This runbook defines the rollback path for releases produced by `.github/workflows/release.yml`.
+
+## Preconditions
+
+- Use an account with permission to create tags and releases.
+- Confirm a rollback owner (`lin-mouren`) and communication channel before execution.
+- Do not delete existing release tags as first response; prefer forward rollback via a new tag.
+
+## Identify rollback target
+
+```bash
+git fetch --tags origin
+git tag --sort=-creatordate | head -n 20
+```
+
+Select:
+- `broken_tag`: currently deployed but faulty tag (example: `v1.2.3`)
+- `stable_tag`: last known good tag (example: `v1.2.2`)
+
+## Execute rollback release
+
+1. Create rollback branch from `stable_tag`:
+
+```bash
+git checkout -b release/rollback-$(date +%Y%m%d-%H%M) "$stable_tag"
+```
+
+2. Create a new rollback tag (do not reuse old tag):
+
+```bash
+rollback_tag="v1.2.4-rollback.1"
+git tag -a "$rollback_tag" -m "rollback: revert production to $stable_tag from $broken_tag"
+git push origin "$rollback_tag"
+```
+
+3. Verify GitHub Actions release run started:
+
+```bash
+gh run list -R lin-mouren/Toonflow-app --workflow "Build and Release" --limit 5
+```
+
+4. Approve `production` environment prompt when requested.
+
+## Post-rollback validation
+
+1. Confirm release artifacts correspond to `stable_tag` code lineage.
+2. Smoke-test startup and critical user paths.
+3. Update incident issue with:
+- `broken_tag`
+- `stable_tag`
+- `rollback_tag`
+- release workflow URL
+- validation checklist results
+
+## Follow-up
+
+1. Open a fix PR on `main` for root cause.
+2. Prepare next normal release tag after fix verification.
+3. Keep rollback issue open until fix release is live.

--- a/docs/upstream-sync-runbook.md
+++ b/docs/upstream-sync-runbook.md
@@ -58,6 +58,7 @@ Workflows:
 - runs on schedule and on manual dispatch
 - fast-forward syncs mirror from upstream
 - creates or updates a PR from mirror to main when there are upstream deltas
+- on ff-only failure: opens/updates a break-glass issue, notifies `@lin-mouren`, and marks workflow failed
 
 ## Governance baseline and snapshot
 
@@ -99,3 +100,14 @@ For personal repositories, GitHub does not support branch-protection push restri
 
 For production-readiness tasks (deployment environment protection, secrets hardening, release traceability), follow:
 - `docs/production-readiness-checklist.md`
+- `docs/release-rollback-runbook.md`
+
+## Optional external notification fan-out
+
+To send break-glass alerts to external systems (Slack/Webhook), set:
+
+```bash
+gh secret set UPSTREAM_SYNC_ALERT_WEBHOOK_URL -R lin-mouren/Toonflow-app
+```
+
+The workflow sends a JSON payload containing `repo`, `reason`, `upstream_sha`, `mirror_sha`, `run_url`, and `issue_url`.

--- a/scripts/github/apply-org-branch-protection.sh
+++ b/scripts/github/apply-org-branch-protection.sh
@@ -34,6 +34,7 @@ fi
 echo "Applying repository settings to ${REPO} ..."
 gh api -X PATCH "repos/${REPO}" \
   -f default_branch=main \
+  -F has_issues=true \
   -F allow_merge_commit=true \
   -F allow_squash_merge=false \
   -F allow_rebase_merge=false \
@@ -41,7 +42,7 @@ gh api -X PATCH "repos/${REPO}" \
 
 echo "Ensuring workflow token permissions ..."
 gh api -X PUT "repos/${REPO}/actions/permissions/workflow" \
-  -f default_workflow_permissions=write \
+  -f default_workflow_permissions=read \
   -F can_approve_pull_request_reviews=true >/dev/null
 
 tmp_main="$(mktemp)"
@@ -58,7 +59,7 @@ cat >"$tmp_main" <<'JSON'
   "enforce_admins": true,
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": false,
-    "require_code_owner_reviews": false,
+    "require_code_owner_reviews": true,
     "required_approving_review_count": 1,
     "require_last_push_approval": false
   },

--- a/scripts/github/apply-personal-branch-baseline.sh
+++ b/scripts/github/apply-personal-branch-baseline.sh
@@ -33,6 +33,7 @@ fi
 echo "Applying personal-repo governance baseline to ${REPO} ..."
 gh api -X PATCH "repos/${REPO}" \
   -f default_branch=main \
+  -F has_issues=true \
   -F allow_merge_commit=true \
   -F allow_squash_merge=false \
   -F allow_rebase_merge=false \
@@ -40,7 +41,7 @@ gh api -X PATCH "repos/${REPO}" \
 
 echo "Ensuring workflow token permissions (required for mirror sync push) ..."
 gh api -X PUT "repos/${REPO}/actions/permissions/workflow" \
-  -f default_workflow_permissions=write \
+  -f default_workflow_permissions=read \
   -F can_approve_pull_request_reviews=true >/dev/null
 
 tmp_main="$(mktemp)"
@@ -57,8 +58,8 @@ cat >"$tmp_main" <<'JSON'
   "enforce_admins": true,
   "required_pull_request_reviews": {
     "dismiss_stale_reviews": false,
-    "require_code_owner_reviews": false,
-    "required_approving_review_count": 0,
+    "require_code_owner_reviews": true,
+    "required_approving_review_count": 1,
     "require_last_push_approval": false
   },
   "restrictions": null,
@@ -104,7 +105,7 @@ cat >"$tmp_master" <<'JSON'
 }
 JSON
 
-echo "Protecting main (PR gate + CI required, review count=0) ..."
+echo "Protecting main (PR gate + CI required, review count=1 + CODEOWNERS) ..."
 gh api -X PUT "repos/${REPO}/branches/main/protection" \
   -H "Accept: application/vnd.github+json" \
   --input "$tmp_main" >/dev/null

--- a/scripts/github/snapshot-governance-state.sh
+++ b/scripts/github/snapshot-governance-state.sh
@@ -37,13 +37,16 @@ merge_commit_allowed="$(gh repo view "$REPO" --json mergeCommitAllowed --jq '.me
 rebase_merge_allowed="$(gh repo view "$REPO" --json rebaseMergeAllowed --jq '.rebaseMergeAllowed')"
 squash_merge_allowed="$(gh repo view "$REPO" --json squashMergeAllowed --jq '.squashMergeAllowed')"
 delete_branch_on_merge="$(gh repo view "$REPO" --json deleteBranchOnMerge --jq '.deleteBranchOnMerge')"
+has_issues="$(gh api "repos/${REPO}" --jq '.has_issues')"
 
 main_required_reviews="$(gh api "repos/${REPO}/branches/main/protection" --jq '.required_pull_request_reviews.required_approving_review_count')"
+main_require_code_owner_reviews="$(gh api "repos/${REPO}/branches/main/protection" --jq '.required_pull_request_reviews.require_code_owner_reviews')"
 main_checks="$(gh api "repos/${REPO}/branches/main/protection" --jq '.required_status_checks.contexts | join(", ")')"
 main_enforce_admins="$(gh api "repos/${REPO}/branches/main/protection" --jq '.enforce_admins.enabled')"
 main_allow_force_pushes="$(gh api "repos/${REPO}/branches/main/protection" --jq '.allow_force_pushes.enabled')"
 main_allow_deletions="$(gh api "repos/${REPO}/branches/main/protection" --jq '.allow_deletions.enabled')"
 main_require_conversation_resolution="$(gh api "repos/${REPO}/branches/main/protection" --jq '.required_conversation_resolution.enabled')"
+default_workflow_permissions="$(gh api "repos/${REPO}/actions/permissions/workflow" --jq '.default_workflow_permissions')"
 
 mirror_enforce_admins="$(gh api "repos/${REPO}/branches/mirror%2Fupstream-main/protection" --jq '.enforce_admins.enabled')"
 mirror_allow_force_pushes="$(gh api "repos/${REPO}/branches/mirror%2Fupstream-main/protection" --jq '.allow_force_pushes.enabled')"
@@ -89,10 +92,13 @@ Generated at:
 - rebase_merge_allowed: \`${rebase_merge_allowed}\`
 - squash_merge_allowed: \`${squash_merge_allowed}\`
 - delete_branch_on_merge: \`${delete_branch_on_merge}\`
+- has_issues: \`${has_issues}\`
+- default_workflow_permissions: \`${default_workflow_permissions}\`
 
 ## Branch protection: main
 
 - required_approving_review_count: \`${main_required_reviews}\`
+- require_code_owner_reviews: \`${main_require_code_owner_reviews}\`
 - required_status_checks: \`${main_checks}\`
 - enforce_admins: \`${main_enforce_admins}\`
 - allow_force_pushes: \`${main_allow_force_pushes}\`


### PR DESCRIPTION
## Summary
- add release rollback runbook for tag-based release workflow
- harden upstream break-glass path with owner mention, step summary, optional webhook fan-out, and explicit failure state
- update production readiness checklist and upstream runbook with finalized status and webhook configuration
- align governance scripts with current secure defaults (issues enabled, workflow token default read, main requires 1+CODEOWNERS)
- refresh governance snapshot to include has_issues, default workflow permissions, and CODEOWNERS review setting

## Validation
- shell syntax checks for updated scripts passed
- upstream sync workflow still succeeds on normal path
- repository protection/security state reflected in snapshot