### PR TITLE
docs: production readiness closure evidence and blocker notes

### DIFF
--- a/docs/governance-snapshot-2026-03-06.md
+++ b/docs/governance-snapshot-2026-03-06.md
@@ -1,0 +1,53 @@
+# Governance Snapshot: lin-mouren/Toonflow-app
+
+Generated at:
+- Local time: 2026-03-06 01:04:44 CST
+- UTC time: 2026-03-05T17:04:44Z
+
+## Repository settings
+
+- default_branch: `main`
+- merge_commit_allowed: `true`
+- rebase_merge_allowed: `false`
+- squash_merge_allowed: `false`
+- delete_branch_on_merge: `true`
+- has_issues: `true`
+- default_workflow_permissions: `read`
+
+## Branch protection: main
+
+- required_approving_review_count: `1`
+- require_code_owner_reviews: `true`
+- required_status_checks: `lint, build`
+- enforce_admins: `true`
+- allow_force_pushes: `false`
+- allow_deletions: `false`
+- required_conversation_resolution: `true`
+
+## Branch protection: mirror/upstream-main
+
+- enforce_admins: `true`
+- allow_force_pushes: `false`
+- allow_deletions: `false`
+- restrictions: `null`
+
+## Mirror alignment
+
+- upstream repository: `HBAI-Ltd/Toonflow-app`
+- upstream default branch: `master`
+- compare status (`mirror/upstream-main...main`): `ahead`
+- compare ahead_by: `27`
+- compare behind_by: `0`
+- mirror sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
+- upstream sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
+- mirror equals upstream: `true`
+
+## Security and deployment hardening status
+
+- secret_scanning: `enabled`
+- secret_scanning_push_protection: `enabled`
+- dependabot_security_updates: `enabled`
+- production_environment_exists: `true`
+- production_can_admins_bypass: `false`
+- production_branch_policy: `{"custom_branch_policies":true,"protected_branches":false}`
+- production_has_required_reviewers: `true`

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -9,18 +9,24 @@ This document operationalizes pending production hardening tasks while the repos
 - Branch model: `main` + `mirror/upstream-main`
 - Current policy: no strict actor-level mirror push restriction
 
-## Current status (as of 2026-03-05)
+## Current status (as of 2026-03-06)
 
 - `issues` is enabled (`has_issues=true`) for break-glass incident tracking.
-- `production` environment has been created with `protected_branches=true`.
+- `production` environment has been created.
+- `production` deployment branch policy is now `custom_branch_policies=true`.
+- `production` deployment sources are restricted to:
+  - `main` (branch)
+  - `v*` (tag)
 - `production` required reviewer is configured (`lin-mouren`).
 - `production` admin bypass is disabled (`can_admins_bypass=false`).
 - `secret_scanning` and `secret_scanning_push_protection` are enabled.
 - `dependabot_security_updates` is enabled.
 - default workflow token permission is `read`; write permissions are job-scoped.
 - `main` protection now requires `1` approval with CODEOWNERS review.
+- upstream sync drill capability is implemented in `.github/workflows/upstream-sync.yml` (`drill_ff_failure`).
 - release rollback runbook exists at `docs/release-rollback-runbook.md`.
-- upstream ff failure fan-out is configured via issue + owner mention + optional webhook secret `UPSTREAM_SYNC_ALERT_WEBHOOK_URL`.
+- upstream ff failure fan-out is configured via issue + owner mention + webhook secret `UPSTREAM_SYNC_ALERT_WEBHOOK_URL`.
+- rehearsal release tag `v0.0.0-alpha.1` was created for production-gate validation.
 
 ## P0: Deployment environment protection
 
@@ -101,6 +107,20 @@ Actions:
 Validation:
 - FF failure creates/updates an issue with run URL and remediation steps.
 - On-call owner receives notification within SLA.
+
+## Open blocker (platform incident)
+
+As of 2026-03-06, GitHub status reports:
+- overall: `Partial System Outage`
+- components: `Actions=major_outage`, `Webhooks=major_outage`
+
+Impact:
+- `workflow_dispatch` calls return HTTP 500.
+- new workflow runs are not being created for current push/tag events.
+
+Deferred closure items after incident recovery:
+1. run upstream drill (`drill_ff_failure=true`) and verify issue + webhook delivery.
+2. re-run release rehearsal with next alpha tag and verify production approval gate + release artifacts.
 
 ## Operations cadence
 

--- a/docs/release-rollback-runbook.md
+++ b/docs/release-rollback-runbook.md
@@ -7,6 +7,9 @@ This runbook defines the rollback path for releases produced by `.github/workflo
 - Use an account with permission to create tags and releases.
 - Confirm a rollback owner (`lin-mouren`) and communication channel before execution.
 - Do not delete existing release tags as first response; prefer forward rollback via a new tag.
+- Confirm GitHub platform health for release orchestration:
+  - [https://www.githubstatus.com](https://www.githubstatus.com)
+  - `Actions` and `Webhooks` should be `operational` before running rollback/rehearsal.
 
 ## Identify rollback target
 
@@ -59,3 +62,9 @@ gh run list -R lin-mouren/Toonflow-app --workflow "Build and Release" --limit 5
 1. Open a fix PR on `main` for root cause.
 2. Prepare next normal release tag after fix verification.
 3. Keep rollback issue open until fix release is live.
+
+## Rehearsal note (2026-03-06)
+
+- Rehearsal tag `v0.0.0-alpha.1` was pushed to validate production deployment gate.
+- During that window, GitHub reported `Actions=major_outage` and `Webhooks=major_outage`, so release workflow runs were not created.
+- Use the next incremental alpha tag (for example `v0.0.0-alpha.2`) after incident recovery to complete rehearsal evidence capture.

--- a/docs/upstream-sync-runbook.md
+++ b/docs/upstream-sync-runbook.md
@@ -56,9 +56,24 @@ Workflows:
 
 `upstream-sync.yml`:
 - runs on schedule and on manual dispatch
+- supports drill mode via `workflow_dispatch` input `drill_ff_failure=true`
 - fast-forward syncs mirror from upstream
 - creates or updates a PR from mirror to main when there are upstream deltas
 - on ff-only failure: opens/updates a break-glass issue, notifies `@lin-mouren`, and marks workflow failed
+- drill mode simulates ff-failure without pushing to `mirror/upstream-main`
+
+## Drill execution record (2026-03-06)
+
+- Code path landed on `main` via PR #12 (merge commit `02a1bb818e62a1a9b23b4a68958e757e822f8799`).
+- Dispatch execution was blocked by GitHub incident:
+  - GitHub status: `Partial System Outage`
+  - Components: `Actions=major_outage`, `Webhooks=major_outage`
+- Deferred verification command when platform recovers:
+
+```bash
+gh workflow run .github/workflows/upstream-sync.yml \
+  -R lin-mouren/Toonflow-app --ref main -f drill_ff_failure=true
+```
 
 ## Governance baseline and snapshot
 
@@ -110,4 +125,4 @@ To send break-glass alerts to external systems (Slack/Webhook), set:
 gh secret set UPSTREAM_SYNC_ALERT_WEBHOOK_URL -R lin-mouren/Toonflow-app
 ```
 
-The workflow sends a JSON payload containing `repo`, `reason`, `upstream_sha`, `mirror_sha`, `run_url`, and `issue_url`.
+The workflow sends a JSON payload containing `repo`, `drill`, `reason`, `upstream_sha`, `mirror_sha`, `run_url`, and `issue_url`.


### PR DESCRIPTION
## Summary
- update upstream sync runbook with drill mode and outage execution record
- update production readiness checklist with current baseline and explicit blocker section
- update release rollback runbook with GitHub status preflight and rehearsal note
- refresh governance snapshot (2026-03-06)

## Notes
- During execution window, GitHub Status reported major outage on Actions/Webhooks.
- Branch/environment protections remain restored to intended baseline.