### PR TITLE
docs: finalize drill and release rehearsal closure evidence

### DIFF
--- a/docs/governance-snapshot-2026-03-06.md
+++ b/docs/governance-snapshot-2026-03-06.md
@@ -1,8 +1,8 @@
 # Governance Snapshot: lin-mouren/Toonflow-app
 
 Generated at:
-- Local time: 2026-03-06 01:04:44 CST
-- UTC time: 2026-03-05T17:04:44Z
+- Local time: 2026-03-06 02:35:06 CST
+- UTC time: 2026-03-05T18:35:06Z
 
 ## Repository settings
 
@@ -36,7 +36,7 @@ Generated at:
 - upstream repository: `HBAI-Ltd/Toonflow-app`
 - upstream default branch: `master`
 - compare status (`mirror/upstream-main...main`): `ahead`
-- compare ahead_by: `27`
+- compare ahead_by: `31`
 - compare behind_by: `0`
 - mirror sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
 - upstream sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -26,7 +26,7 @@ This document operationalizes pending production hardening tasks while the repos
 - upstream sync drill capability is implemented in `.github/workflows/upstream-sync.yml` (`drill_ff_failure`).
 - release rollback runbook exists at `docs/release-rollback-runbook.md`.
 - upstream ff failure fan-out is configured via issue + owner mention + webhook secret `UPSTREAM_SYNC_ALERT_WEBHOOK_URL`.
-- rehearsal release tag `v0.0.0-alpha.1` was created for production-gate validation.
+- rehearsal release tag `v0.0.0-alpha.1` completed end-to-end production gate validation.
 
 ## P0: Deployment environment protection
 
@@ -108,19 +108,22 @@ Validation:
 - FF failure creates/updates an issue with run URL and remediation steps.
 - On-call owner receives notification within SLA.
 
-## Open blocker (platform incident)
+## Closure evidence (2026-03-06)
 
-As of 2026-03-06, GitHub status reports:
-- overall: `Partial System Outage`
-- components: `Actions=major_outage`, `Webhooks=major_outage`
+1. Release rehearsal
+- tag: `v0.0.0-alpha.1`
+- workflow run: `22728142335`
+- run URL: `https://github.com/lin-mouren/Toonflow-app/actions/runs/22728142335`
+- production environment approval completed by required reviewer
+- GitHub Release created with multi-platform artifacts:
+  - `https://github.com/lin-mouren/Toonflow-app/releases/tag/v0.0.0-alpha.1`
 
-Impact:
-- `workflow_dispatch` calls return HTTP 500.
-- new workflow runs are not being created for current push/tag events.
-
-Deferred closure items after incident recovery:
-1. run upstream drill (`drill_ff_failure=true`) and verify issue + webhook delivery.
-2. re-run release rehearsal with next alpha tag and verify production approval gate + release artifacts.
+2. Upstream drill rehearsal
+- workflow run: `22730995682` (expected failure path)
+- run URL: `https://github.com/lin-mouren/Toonflow-app/actions/runs/22730995682`
+- drill issue: `#16` (created then closed after verification)
+- webhook fan-out: `Webhook status: sent`
+- mirror branch integrity: unchanged SHA before/after drill
 
 ## Operations cadence
 

--- a/docs/release-rollback-runbook.md
+++ b/docs/release-rollback-runbook.md
@@ -65,6 +65,8 @@ gh run list -R lin-mouren/Toonflow-app --workflow "Build and Release" --limit 5
 
 ## Rehearsal note (2026-03-06)
 
-- Rehearsal tag `v0.0.0-alpha.1` was pushed to validate production deployment gate.
-- During that window, GitHub reported `Actions=major_outage` and `Webhooks=major_outage`, so release workflow runs were not created.
-- Use the next incremental alpha tag (for example `v0.0.0-alpha.2`) after incident recovery to complete rehearsal evidence capture.
+- Rehearsal tag `v0.0.0-alpha.1` was pushed and release workflow completed successfully.
+- Workflow run: `22728142335`
+- Run URL: `https://github.com/lin-mouren/Toonflow-app/actions/runs/22728142335`
+- Release URL: `https://github.com/lin-mouren/Toonflow-app/releases/tag/v0.0.0-alpha.1`
+- Production environment approval gate was exercised and approved before release job execution.

--- a/docs/upstream-sync-runbook.md
+++ b/docs/upstream-sync-runbook.md
@@ -64,16 +64,19 @@ Workflows:
 
 ## Drill execution record (2026-03-06)
 
-- Code path landed on `main` via PR #12 (merge commit `02a1bb818e62a1a9b23b4a68958e757e822f8799`).
-- Dispatch execution was blocked by GitHub incident:
-  - GitHub status: `Partial System Outage`
-  - Components: `Actions=major_outage`, `Webhooks=major_outage`
-- Deferred verification command when platform recovers:
-
-```bash
-gh workflow run .github/workflows/upstream-sync.yml \
-  -R lin-mouren/Toonflow-app --ref main -f drill_ff_failure=true
-```
+- Code path landed on `main` via:
+  - PR #12 (`02a1bb818e62a1a9b23b4a68958e757e822f8799`)
+  - PR #15 (`3f8d24746557ecc3d785d1fdfb96cedf43596aed`) to fix `gh` repo context in non-checkout jobs.
+- Drill run completed:
+  - Workflow run: `22730995682` (expected `failure`, because break-glass job exits `1` by design)
+  - URL: `https://github.com/lin-mouren/Toonflow-app/actions/runs/22730995682`
+- Validation results:
+  - break-glass drill issue created: #16
+  - webhook fan-out: `Webhook status: sent`
+  - mirror unchanged: `origin/mirror/upstream-main` SHA unchanged
+  - no `mirror/upstream-main -> main` PR noise created
+- Drill issue was closed after verification:
+  - `https://github.com/lin-mouren/Toonflow-app/issues/16`
 
 ## Governance baseline and snapshot
 


### PR DESCRIPTION
## Summary
- record successful release rehearsal evidence (`v0.0.0-alpha.1`)
- record successful drill run evidence (`run 22730995682`, issue #16 closed)
- refresh governance snapshot timestamp and current protections

## Validation
- mirror SHA unchanged through drill
- main/mirror protection and production deployment policies unchanged