### PR TITLE
docs: refresh governance snapshot after security closure

### DIFF
--- a/docs/governance-snapshot-2026-03-06.md
+++ b/docs/governance-snapshot-2026-03-06.md
@@ -1,8 +1,8 @@
 # Governance Snapshot: lin-mouren/Toonflow-app
 
 Generated at:
-- Local time: 2026-03-06 02:35:06 CST
-- UTC time: 2026-03-05T18:35:06Z
+- Local time: 2026-03-06 09:30:58 CST
+- UTC time: 2026-03-06T01:30:58Z
 
 ## Repository settings
 
@@ -36,7 +36,7 @@ Generated at:
 - upstream repository: `HBAI-Ltd/Toonflow-app`
 - upstream default branch: `master`
 - compare status (`mirror/upstream-main...main`): `ahead`
-- compare ahead_by: `31`
+- compare ahead_by: `41`
 - compare behind_by: `0`
 - mirror sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`
 - upstream sha: `641c98037c4f6cb95dff7c98addfadb88cf454ca`

--- a/docs/production-readiness-checklist.md
+++ b/docs/production-readiness-checklist.md
@@ -27,6 +27,7 @@ This document operationalizes pending production hardening tasks while the repos
 - release rollback runbook exists at `docs/release-rollback-runbook.md`.
 - upstream ff failure fan-out is configured via issue + owner mention + webhook secret `UPSTREAM_SYNC_ALERT_WEBHOOK_URL`.
 - rehearsal release tag `v0.0.0-alpha.1` completed end-to-end production gate validation.
+- Dependabot open alerts: `0` (queried via API on 2026-03-06).
 
 ## P0: Deployment environment protection
 
@@ -124,6 +125,11 @@ Validation:
 - drill issue: `#16` (created then closed after verification)
 - webhook fan-out: `Webhook status: sent`
 - mirror branch integrity: unchanged SHA before/after drill
+
+3. Security closure
+- PR: `#21` (`chore(security): remove sqlite3 chain and refresh vulnerable transitives`)
+- merged commit: `4957eb53ed634c38f602558b244e7be4fbb9ec6c`
+- result: `dependabot alerts state=open` count is `0`
 
 ## Operations cadence
 


### PR DESCRIPTION
## Summary
- refresh governance snapshot timestamp and mirror/main compare counters
- record Dependabot open-alert count `0` after PR #21
- append security closure evidence to production checklist

## Notes
- documentation-only update, no runtime code changes
